### PR TITLE
HAAR-1095: ⬆️ update to spring-boot-plugin-4.8.0-beta

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,6 +1,6 @@
 plugins {
-  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.7.4"
-  kotlin("plugin.spring") version "1.7.22"
+  id("uk.gov.justice.hmpps.gradle-spring-boot") version "4.8.0-beta"
+  kotlin("plugin.spring") version "1.8.0"
 }
 
 dependencyCheck {


### PR DESCRIPTION
includes spring boot 2.7.7 and kotlin 1.8