### PR TITLE
HAAR-2192: sslrootcert location is mandatory filed with valid location

### DIFF
--- a/src/main/resources/application-local-postgres.yml
+++ b/src/main/resources/application-local-postgres.yml
@@ -5,7 +5,7 @@ spring:
     password: admin_password
     properties:
       sslMode: DISABLE
-      sslRootCert:
+      sslRootCert: //home
   flyway:
     url: jdbc:postgresql://localhost:5432/auth-db?sslmode=prefer
     user: admin


### PR DESCRIPTION
sslrootcert location is mandatory filed with valid location. (SSL is disabled in local-postgress profile)